### PR TITLE
chore(deps): update external-dns docker tag to v8.8.4

### DIFF
--- a/install/dependencies.json
+++ b/install/dependencies.json
@@ -14,7 +14,7 @@
   "external-dns": {
     "chart": "external-dns",
     "repo": "oci://registry-1.docker.io/bitnamicharts",
-    "version": "8.8.3",
+    "version": "8.8.4",
     "appVersion": "0.17.0"
   }
 }


### PR DESCRIPTION
| datasource | package                    | from  | to    |
| ---------- | -------------------------- | ----- | ----- |
| docker     | bitnamicharts/external-dns | 8.8.3 | 8.8.4 |